### PR TITLE
chore: remove deprecated bandit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,8 @@ repos:
       - id: flake8
         additional_dependencies: [flake8-annotations]
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.4
+    rev: 1.7.5
     hooks:
       - id: bandit
-        args: [--skip, B101, --recursive]
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,8 +36,8 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-annotations]
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
-    rev: v1.0.6
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.4
     hooks:
-      - id: python-bandit-vulnerability-check
-        args: [--skip, B101, --recursive, clumper]
+      - id: bandit
+        args: [--skip, B101, --recursive]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,11 @@ exclude = ["**/node_modules", "**/__pycache__", "**/package/**"]
 convention = "google"
 add_ignore = ["D100", "D107"]
 
+[tool.bandit]
+# B603:subprocess_without_shell_equals_true is skipped because of the nature of the wrapper
+# B404:blacklist is skipped to import subprocess
+skips = ["B101", "B603", "B404"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-DEFAULT_REGION = "pl-waw"
+DEFAULT_REGION = "fr-par"
 SCALEWAY_API_URL = "https://api.scaleway.com/"
 
 COLD_START_TIMEOUT = 20

--- a/tests/integrations/deploy/test_api_backend.py
+++ b/tests/integrations/deploy/test_api_backend.py
@@ -52,7 +52,7 @@ def test_integration_deploy_existing_function(scaleway_project: str):  # noqa
 
     import time
 
-    time.sleep(30)
+    time.sleep(60)
 
     # Check updated message content
     resp = trigger_function(url)

--- a/tests/integrations/deploy/test_api_backend.py
+++ b/tests/integrations/deploy/test_api_backend.py
@@ -50,6 +50,10 @@ def test_integration_deploy_existing_function(scaleway_project: str):  # noqa
         app_path=constants.APP_FIXTURES_PATH / "app_updated.py",
     )
 
+    import time
+
+    time.sleep(30)
+
     # Check updated message content
     resp = trigger_function(url)
     assert resp.text == app_updated.MESSAGE

--- a/tests/integrations/deploy/test_sf_backend.py
+++ b/tests/integrations/deploy/test_sf_backend.py
@@ -50,6 +50,10 @@ def test_integration_deploy_existing_function_serverless_backend(
         app_path=constants.APP_FIXTURES_PATH.joinpath("app_updated.py"),
     )
 
+    import time
+
+    time.sleep(30)
+
     # Check updated message content
     resp = trigger_function(url)
     assert resp.text == app_updated.MESSAGE

--- a/tests/integrations/project_fixture.py
+++ b/tests/integrations/project_fixture.py
@@ -31,7 +31,7 @@ def scaleway_project() -> t.Iterator[ProjectID]:
 
 
 def _create_scaleway_project(client: Client) -> ProjectID:
-    name = f"apifw-{COMMIT_SHA[:7]}-{random.randint(0, 9999)}" # nosec # unsafe rng
+    name = f"apifw-{COMMIT_SHA[:7]}-{random.randint(0, 9999)}"  # nosec # unsafe rng
     project = AccountV2API(client).create_project(
         name=name,
         description="Created by the Serverless API Framework integration suite.",

--- a/tests/integrations/project_fixture.py
+++ b/tests/integrations/project_fixture.py
@@ -31,7 +31,7 @@ def scaleway_project() -> t.Iterator[ProjectID]:
 
 
 def _create_scaleway_project(client: Client) -> ProjectID:
-    name = f"apifw-{COMMIT_SHA[:7]}-{random.randint(0, 9999)}"
+    name = f"apifw-{COMMIT_SHA[:7]}-{random.randint(0, 9999)}" # nosec # unsafe rng
     project = AccountV2API(client).create_project(
         name=name,
         description="Created by the Serverless API Framework integration suite.",

--- a/tests/test_deploy/test_backends/test_scaleway_api_backend.py
+++ b/tests/test_deploy/test_backends/test_scaleway_api_backend.py
@@ -38,7 +38,7 @@ def get_test_backend() -> ScalewayApiBackend:
     client = Client(
         access_key="SCWXXXXXXXXXXXXXXXXX",
         # The uuid is validated
-        secret_key="498cce73-2a07-4e8c-b8ef-8f988e3c6929",
+        secret_key="498cce73-2a07-4e8c-b8ef-8f988e3c6929",  # nosec # fake data
         default_region=REGION_FR_PAR,
     )
     backend = ScalewayApiBackend(app, client, True)


### PR DESCRIPTION
## Summary

**_What's changed?_**

This changes the bandit pre-commit hook to use a non-deprecated mirror.

**_Why do we need this?_**

It's always good to have some sort of code security analysis tool to avoid leaking secrets. The deprecated mirror had some issues and was not using the latest release of bandit.

**_How have you tested it?_**

bandit hooks can run on the whole codebase.

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
