### PR TITLE
Timeout when deleting registry + Add valid target for route creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scw-serverless"
-version = "1.0.0"
+version = "1.0.1"
 description = "Framework for writing serverless APIs in Python, using Scaleway functions and containers."
 authors = ["Scaleway Serverless Team <opensource@scaleway.com>"]
 readme = "README.md"
@@ -14,7 +14,7 @@ keywords = ["serverless", "scaleway", "functions", "cloud", "faas"]
 # "Development Status :: 4 - Beta"
 # "Development Status :: 5 - Production/Stable"
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Topic :: Software Development :: Libraries :: Application Frameworks",

--- a/scw_serverless/gateway/gateway_manager.py
+++ b/scw_serverless/gateway/gateway_manager.py
@@ -55,6 +55,7 @@ class GatewayManager:
         # otherwise we might accidentally delete a route we previously created.
         # If it has the same relative_url but different http methods.
         for function in routed_functions:
+            function.gateway_route.target = "https://"
             self.gateway_client.delete_route(function.gateway_route)  # type: ignore
 
         for function in routed_functions:

--- a/scw_serverless/gateway/gateway_manager.py
+++ b/scw_serverless/gateway/gateway_manager.py
@@ -50,14 +50,6 @@ class GatewayManager:
             if function.gateway_route
         ]
 
-        # The Gateway deletes routes based on the relative_url,
-        # so we need to cleanup all routes at the start,
-        # otherwise we might accidentally delete a route we previously created.
-        # If it has the same relative_url but different http methods.
-        for function in routed_functions:
-            function.gateway_route.target = "https://"
-            self.gateway_client.delete_route(function.gateway_route)  # type: ignore
-
         for function in routed_functions:
             if function.name not in created_functions:
                 raise RuntimeError(
@@ -69,6 +61,4 @@ class GatewayManager:
             function.gateway_route.target = target  # type: ignore
 
         for function in routed_functions:
-            if not function.gateway_route:
-                continue
-            self.gateway_client.create_route(function.gateway_route)
+            self.gateway_client.create_route(function.gateway_route) # type: ignore

--- a/tests/integrations/project_fixture.py
+++ b/tests/integrations/project_fixture.py
@@ -9,6 +9,7 @@ from scaleway.account.v2 import AccountV2API
 from scaleway.function.v1beta1 import FunctionV1Beta1API
 from scaleway.registry.v1 import RegistryV1API
 from scaleway_core.api import ScalewayException
+from scaleway_core.utils import WaitForOptions
 
 from .utils import create_client
 
@@ -62,7 +63,7 @@ def _cleanup_project(client: Client, project_id: ProjectID):
                 raise e
     for registry in registries:
         try:
-            registry_api.wait_for_namespace(namespace_id=registry.id)
+            registry_api.wait_for_namespace(namespace_id=registry.id, options=WaitForOptions(timeout=600))
         except ScalewayException as e:
             if e.status_code != 404:
                 raise e

--- a/tests/test_gateway/test_gateway_manager.py
+++ b/tests/test_gateway/test_gateway_manager.py
@@ -87,14 +87,6 @@ def test_gateway_manager_update_routes(
         json={"functions": []},
     )
 
-    # We should attempt to delete the route
-    mocked_responses.delete(
-        MOCK_GATEWAY_URL + "/scw",  # type: ignore
-        match=[
-            header_matcher({"X-Auth-Token": MOCK_GATEWAY_API_KEY}),
-            json_params_matcher(params=function.gateway_route.asdict()),  # type: ignore
-        ],
-    )
     # We should attempt to create the route
     mocked_responses.post(
         MOCK_GATEWAY_URL + "/scw",  # type: ignore


### PR DESCRIPTION
## Summary

**_What's changed?_**

This PR implements the following features:

1/ Increase timeout when deleting registry namespaces.
2/ Add target with valid prefix before routes creation and remove start clean up. If an endpoint exists with the same relative URL, the gateway deletes it automatically before creation.

**_Why do we need this?_**

1/ Some namespaces take more than 300s to be deleted so when a timeout is raised, some project cannot be deleted.
2/ When updating routes, the clean up up process is useless since the gateway do it for endpoints with the same relative URL. A target with valid prefix is created for all deployed functions 

**_How have you tested it?_**

Run:

```
poetry run pytest tests/integration/gateway -s --ignore=integrations
```

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation